### PR TITLE
Replace attributes with Builder API

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,12 +1,10 @@
 ﻿using ICsi.Core;
 
-using McMaster.Extensions.CommandLineUtils;
-
 namespace ICsi
 {
     internal static class Program
     {
         private static int Main(string[] args)
-            => CommandLineApplication.Execute<Application>(args);
+            => new Application().Run(args);
     }
 }


### PR DESCRIPTION
The Application.cs file has attributes that define the command-line options in ICsi, so it must be replaced with the Builder API.