### PR TITLE
Remove ReplCommands class and update script engines

### DIFF
--- a/src/Roslyn/CompiledScriptEngine.cs
+++ b/src/Roslyn/CompiledScriptEngine.cs
@@ -19,6 +19,7 @@ namespace ICsi.Roslyn
         private Script<object> _script;
 
         public ScriptEngineOptions Options { get; }
+        public ScriptState State { get => null; }
 
         public CompiledScriptEngine(ScriptEngineOptions options)
         {

--- a/src/Roslyn/IScriptEngine.cs
+++ b/src/Roslyn/IScriptEngine.cs
@@ -1,7 +1,10 @@
+using Microsoft.CodeAnalysis.Scripting;
+
 namespace ICsi.Roslyn
 {
     internal interface IScriptEngine
     {
+        ScriptState State { get; }
         ScriptEngineOptions Options { get; }
         ScriptResult Run(string code);
     }

--- a/src/Roslyn/SimpleScriptEngine.cs
+++ b/src/Roslyn/SimpleScriptEngine.cs
@@ -18,6 +18,7 @@ namespace ICsi.Roslyn
         private ScriptState? _state;
 
         public ScriptEngineOptions Options { get; }
+        public ScriptState? State { get => _state; }
 
         internal SimpleScriptEngine(ScriptEngineOptions options)
         {


### PR DESCRIPTION
This pull request removes ReplCommands nested class from the Repl class and adds State property to the IScriptEngine and its implementations.