### PR TITLE
Bug fix 2

### DIFF
--- a/src/Core/Repl.Submission.cs
+++ b/src/Core/Repl.Submission.cs
@@ -50,7 +50,8 @@ namespace ICsi.Core
                     if (_cursorTop + lineCount == Console.WindowHeight)
                     {
                         Console.SetCursorPosition(0, Console.WindowHeight - 1);
-                        Console.WriteLine();
+                        if (lineCount > 1)
+                            Console.WriteLine();
                         if (_cursorTop > 0)
                             _cursorTop--;
                     }


### PR DESCRIPTION
Fixed a bug where the Render() function writes line terminations even if the line count is less than one.