### PR TITLE
Azure Pipeline changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ICsi
 
-ICsi is a new REPL (read-eval-print-loop) designed to run C# code. It supports only .NET Core 3.1 and newer versions.
+ICsi is a new REPL (read-eval-print-loop) designed to run C# code. It supports only .NET 7.0 and newer versions.
 
 ## How can i install ICsi?
 To install ICsi, you will need the following:
-* .NET Core 3.1 LTS or newer
-* Windows 7 (or newer) or Linux (any distribution supported by .NET Core)
+* .NET 7 or newer
+* Windows 10 (or 11) or Linux (any distribution supported by .NET)
 
 Open PowerShell in Windows (or bash in Linux), and type the following:
 ```
@@ -28,8 +28,8 @@ It depends if you installed the tool locally, globally or inside a specific path
 
 Requirements:
 
-* .NET Core 3.1 LTS or newer (you can also use the latest preview of .NET 5 if you want)
-* Visual Studio 2019 (optional, but it is important for debugging)
+* .NET 7 (you can also use the latest preview of .NET 8 if you want)
+* Visual Studio 2022 (optional, but it is important for debugging)
 * Git (latest version)
 * PowerShell Core (on both Windows and Linux)
 

--- a/azure-pipelines-distribution.yml
+++ b/azure-pipelines-distribution.yml
@@ -38,8 +38,9 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '5.x'
+    version: '7.0'
     includePreviewVersions: true
+    performMultiLevelLookup: true
 - task: DotNetCoreCLI@2
   inputs:
     command: 'restore'

--- a/azure-pipelines-distribution.yml
+++ b/azure-pipelines-distribution.yml
@@ -38,7 +38,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '7.0'
+    version: '7.x'
     includePreviewVersions: true
     performMultiLevelLookup: true
 - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ steps:
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'
-    version: '5.x'
+    version: '7.x'
     includePreviewVersions: true
     performMultiLevelLookup: true
 

--- a/src/ICsi.csproj
+++ b/src/ICsi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <AssemblyName>ICsi</AssemblyName>
 


### PR DESCRIPTION
I had to make one important change into the YAML files requires for Azure Pipelines: change target framework to .NET 7 and drop support for .NET Core 3.1 as it reaches EOL (end of life).